### PR TITLE
Zmiany w nazwach statków

### DIFF
--- a/Data/CliLoc.csv
+++ b/Data/CliLoc.csv
@@ -73206,7 +73206,7 @@ Number;Text
 1116488;You have lost the duel... 
 1116489;Your team has lost the duel... 
 1116490;You step into a puddle of water splashing yourself. 
-1116491;Rowboat Deed 
+1116491;Lodka 
 1116492;Survival 
 1116493;Team 
 1116494;Public 
@@ -106732,7 +106732,7 @@ Number;Text
 1150014;*** Salis takes the ingredients and slithers to the table to experiment.  After a few minutes of experimenting and tasting it slithers back to you. ***<br><br>I have discovered the recipe to blackrock stew, the secret to the bane dragon's power.  As-s-s promised, I will share it with you.  Thank you for your assis-s-stance. 
 1150015;Your backpack is too full for switching language of the book! Please make room and try again. 
 1150016;maly kawalek podmroczniaka
-1150017;Britannian Ship Deed 
+1150017;Kontrakt na Ogromny Galeon 
 1150018;Focus 
 1150019;Otis' Original Homemade Brew 
 1150020;Apple Isle Whiskey 
@@ -106815,7 +106815,7 @@ Number;Text
 1150097;Please enter maximum damage by snowball. 
 1150098;Please enter minimum damage by snowball. 
 1150099;You may not transfer a character during a character copy. 
-1150100;Britannian Ship 
+1150100;Ogromny Galeon
 1150101;Treasure Maps: ~1_val~ 
 1150102;Seeds: ~1_val~ 
 1150103;Messages in Bottles: ~1_val~ 


### PR DESCRIPTION
Zmiana nazw statków Britannian Ship na Ogromny Galeon, RawBoat na łódka.