### PR TITLE
Cena farb do statków

### DIFF
--- a/Scripts/VendorInfo/SBBoatPainter.cs
+++ b/Scripts/VendorInfo/SBBoatPainter.cs
@@ -15,15 +15,15 @@ namespace Server.Mobiles
         {
             public InternalBuyInfo()
             {
-                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 6256, 20, 4011, 276, new object[] { 276 }));
-                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 6256, 20, 4011, 396, new object[] { 396 }));
-                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 6256, 20, 4011, 516, new object[] { 516 }));
-                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 6256, 20, 4011, 1900, new object[] { 1900 }));
-                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 6256, 20, 4011, 251, new object[] { 251 }));
-                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 6256, 20, 4011, 246, new object[] { 246 }));
-                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 6256, 20, 4011, 2213, new object[] { 2213 }));
-                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 6256, 20, 4011, 36, new object[] { 36 }));
-                Add(new GenericBuyInfo("Srodek do usuwania farby do statku", typeof(BoatPaintRemover), 6256, 20, 4011, 0));
+                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 25000, 20, 4011, 276, new object[] { 276 }));
+                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 25000, 20, 4011, 396, new object[] { 396 }));
+                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 25000, 20, 4011, 516, new object[] { 516 }));
+                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 25000, 20, 4011, 1900, new object[] { 1900 }));
+                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 25000, 20, 4011, 251, new object[] { 251 }));
+                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 25000, 20, 4011, 246, new object[] { 246 }));
+                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 25000, 20, 4011, 2213, new object[] { 2213 }));
+                Add(new GenericBuyInfo("Farba do statku", typeof(BoatPaint), 25000, 20, 4011, 36, new object[] { 36 }));
+                Add(new GenericBuyInfo("Srodek do usuwania farby do statku", typeof(BoatPaintRemover), 10000, 20, 4011, 0));
             }
         }
 


### PR DESCRIPTION
Zmieniono cenę farb do statków z 6256gp na 25000 gp, oraz cene zmywacza do farby z 6256gp na 10000 gp.